### PR TITLE
add tables so there arent tr tags right under td tags

### DIFF
--- a/EED_Payment_Methods_Pro_More_Payment_Methods.module.php
+++ b/EED_Payment_Methods_Pro_More_Payment_Methods.module.php
@@ -118,21 +118,23 @@ class EED_Payment_Methods_Pro_More_Payment_Methods extends EED_Module
             $subsections,
             array(
                 'activate_another' => new EE_Form_Section_HTML(
-                    EEH_HTML::tr(
-                        EEH_HTML::th() .
-                        EEH_HTML::td(
-                            EEH_HTML::link(
-                                EE_Admin_Page::add_query_args_and_nonce(
-                                    array(
-                                        'action'              => 'activate_another_payment_method',
-                                        'payment_method_type' => $payment_method->type(),
+                    EEH_HTML::table(
+                        EEH_HTML::tr(
+                            EEH_HTML::th() .
+                            EEH_HTML::td(
+                                EEH_HTML::link(
+                                    EE_Admin_Page::add_query_args_and_nonce(
+                                        array(
+                                            'action'              => 'activate_another_payment_method',
+                                            'payment_method_type' => $payment_method->type(),
+                                        ),
+                                        $url
                                     ),
-                                    $url
-                                ),
-                                $activate_another_text,
-                                $activate_another_text,
-                                'activate_another_' . $payment_method->slug(),
-                                'espresso-button button-secondary'
+                                    $activate_another_text,
+                                    $activate_another_text,
+                                    'activate_another_' . $payment_method->slug(),
+                                    'espresso-button button-secondary'
+                                )
                             )
                         )
                     )
@@ -144,21 +146,23 @@ class EED_Payment_Methods_Pro_More_Payment_Methods extends EED_Module
             $subsections,
             array(
                 'permanently_delete' => new EE_Form_Section_HTML(
-                    EEH_HTML::tr(
-                        EEH_HTML::th() .
-                        EEH_HTML::td(
-                            EEH_HTML::link(
-                                EE_Admin_Page::add_query_args_and_nonce(
-                                    array(
-                                        'action'         => 'delete_payment_method',
-                                        'payment_method' => $payment_method->slug(),
+                    EEH_HTML::table(
+                        EEH_HTML::tr(
+                            EEH_HTML::th() .
+                            EEH_HTML::td(
+                                EEH_HTML::link(
+                                    EE_Admin_Page::add_query_args_and_nonce(
+                                        array(
+                                            'action'         => 'delete_payment_method',
+                                            'payment_method' => $payment_method->slug(),
+                                        ),
+                                        $url
                                     ),
-                                    $url
-                                ),
-                                $delete_text,
-                                $delete_text,
-                                'delete_' . $payment_method->slug(),
-                                'espresso-button button-secondary delete delete-payment-method'
+                                    $delete_text,
+                                    $delete_text,
+                                    'delete_' . $payment_method->slug(),
+                                    'espresso-button button-secondary delete delete-payment-method'
+                                )
                             )
                         )
                     )
@@ -253,33 +257,30 @@ class EED_Payment_Methods_Pro_More_Payment_Methods extends EED_Module
 
         return array(
             new EE_Form_Section_HTML(
-                EEH_HTML::tr(
-                    EEH_HTML::td(
+                EEH_HTML::no_row(
                         $payment_method->type_obj()->introductory_html(),
-                        '',
-                        '',
-                        '',
-                        'colspan="2"'
-                    )
+                        2
                 ) .
-                EEH_HTML::tr(
-                    EEH_HTML::th(
-                        EEH_HTML::label(__('Click to Activate ', 'event_espresso'))
-                    ) .
-                    EEH_HTML::td(
-                        EEH_HTML::link(
-                            EE_Admin_Page::add_query_args_and_nonce(
-                                array(
-                                    'action'              => 'activate_payment_method',
-                                    'payment_method_type' => $payment_method->type(),
-                                    'payment_method_slug' => $payment_method->slug(),
+                EEH_HTML::table(
+                    EEH_HTML::tr(
+                        EEH_HTML::th(
+                            EEH_HTML::label(__('Click to Activate ', 'event_espresso'))
+                        ) .
+                        EEH_HTML::td(
+                            EEH_HTML::link(
+                                EE_Admin_Page::add_query_args_and_nonce(
+                                    array(
+                                        'action'              => 'activate_payment_method',
+                                        'payment_method_type' => $payment_method->type(),
+                                        'payment_method_slug' => $payment_method->slug(),
+                                    ),
+                                    EE_PAYMENTS_ADMIN_URL
                                 ),
-                                EE_PAYMENTS_ADMIN_URL
-                            ),
-                            $link_text_and_title,
-                            $link_text_and_title,
-                            'activate_' . $payment_method->slug(),
-                            'espresso-button-green button-primary'
+                                $link_text_and_title,
+                                $link_text_and_title,
+                                'activate_' . $payment_method->slug(),
+                                'espresso-button-green button-primary'
+                            )
                         )
                     )
                 )

--- a/EED_Payment_Methods_Pro_More_Payment_Methods.module.php
+++ b/EED_Payment_Methods_Pro_More_Payment_Methods.module.php
@@ -258,8 +258,8 @@ class EED_Payment_Methods_Pro_More_Payment_Methods extends EED_Module
         return array(
             new EE_Form_Section_HTML(
                 EEH_HTML::no_row(
-                        $payment_method->type_obj()->introductory_html(),
-                        2
+                    $payment_method->type_obj()->introductory_html(),
+                    2
                 ) .
                 EEH_HTML::table(
                     EEH_HTML::tr(


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixes markup so there aren't tr tags right under td tags (see https://github.com/eventespresso/event-espresso-core/issues/1181).


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Activate payment methods pro. go to the payment methods page. It should look like when master branch is activated. If you inspect source, search for the text "Activate Another". There should be no tr tags right under td tags just before it. Same thing when you search for "Permanently Delete"

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
