### PR TITLE
In event editor metabox set a standard label size

### DIFF
--- a/admin/payment_methods_pro/espresso_events_Payment_Methods_Pro_Hooks.class.php
+++ b/admin/payment_methods_pro/espresso_events_Payment_Methods_Pro_Hooks.class.php
@@ -18,7 +18,7 @@ class espresso_events_Payment_Methods_Pro_Hooks extends EE_Admin_Hooks
             0 => array(
                 'page_route' => array( 'edit', 'create_new' ),
                 'func'       => 'event_specific_payment_methods',
-                'label'      => __('Payment Methods', 'event_espresso'),
+                'label'      => esc_html__('Payment Methods', 'event_espresso'),
                 'priority'   => 'default',
                 'context'    => 'side',
             ),
@@ -96,7 +96,7 @@ class espresso_events_Payment_Methods_Pro_Hooks extends EE_Admin_Hooks
         $subsections = array();
         foreach ($payment_methods_grouped_by_type as $type => $payment_methods_of_type) {
             $options = array(
-                0 => __('do not use', 'event_espresso'),
+                0 => esc_html__('do not use', 'event_espresso'),
             );
             foreach ($payment_methods_of_type as $PMD_ID => $name) {
                 $options[ $PMD_ID ] = $name;

--- a/admin/payment_methods_pro/espresso_events_Payment_Methods_Pro_Hooks.class.php
+++ b/admin/payment_methods_pro/espresso_events_Payment_Methods_Pro_Hooks.class.php
@@ -112,6 +112,8 @@ class espresso_events_Payment_Methods_Pro_Hooks extends EE_Admin_Hooks
                     'default'                => ! empty($available_for_this_type) ? key($available_for_this_type)
                         : 0,
                     'normalization_strategy' => new EE_Int_Normalization(),
+                    'label_size'             => 11,
+                    'enforce_label_size'     => true,
                 )
             );
         }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
This was a problem because some of the options can't be read:
![Screen Shot 2020-04-22 at 1 25 05 PM](https://user-images.githubusercontent.com/891156/80014921-02364900-849f-11ea-97dc-0aa3d677d926.png)
this too:
![Screen Shot 2020-04-22 at 1 25 44 PM](https://user-images.githubusercontent.com/891156/80014942-095d5700-849f-11ea-9f67-14973e2507de.png)

Standardizing the label sizes via the forms systems helped:
![Screen Shot 2020-04-22 at 1 21 58 PM](https://user-images.githubusercontent.com/891156/80014998-1c702700-849f-11ea-8697-82879bf568d2.png)
and if you move the metabox out of the sidebar and into the main column:
![Screen Shot 2020-04-22 at 1 22 19 PM](https://user-images.githubusercontent.com/891156/80015038-2abe4300-849f-11ea-9b53-498cbcbe177d.png)

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

- [x] Activate PM Pro add-on and activate several PM's (ideally with names that have a variety of character lengths, like Stripe and PayPal Express with Smart buttons)
- [x] Go to edit an event and view the PM Pro metabox

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
